### PR TITLE
Added node.js installed via NuGet to PATH

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -3,5 +3,7 @@ cls
 NuGet.exe "Install" "FAKE" "-OutputDirectory" "packages" "-ExcludeVersion"
 NuGet.exe "Install" "OctopusTools" "-OutputDirectory" "packages" "-ExcludeVersion"
 NuGet.exe "Install" "Node.js" "-OutputDirectory" "packages" "-ExcludeVersion"
+SET NodeJsPath=%~dp0packages\Node.js
+SET PATH=%PATH%;%NodeJsPath%
 NuGet.exe "Install" "Npm.js" "-OutputDirectory" "packages" "-ExcludeVersion"
 "packages\FAKE\tools\Fake.exe" build.fsx %*


### PR DESCRIPTION
- Gulp tries to use a global install of node.js instead of the node.js version installed via nuget. 

If a dev already has node.js installed globally, I'm not sure what happens. Might want to test that :)
